### PR TITLE
no disks

### DIFF
--- a/dracut/30ignition/ignition-files.service
+++ b/dracut/30ignition/ignition-files.service
@@ -9,8 +9,8 @@ After=initrd-root-fs.target
 #Requires=ignition-setup.service ignition-disks.service
 #After=ignition-setup.service ignition-disks.service
 
-Requires=ignition-disks.service
-After=ignition-disks.service
+#Requires=ignition-disks.service
+#After=ignition-disks.service
 
 Requires=ignition-remount-sysroot.service
 After=ignition-remount-sysroot.service

--- a/dracut/30ignition/ignition-generator
+++ b/dracut/30ignition/ignition-generator
@@ -37,7 +37,7 @@ add_requires() {
 # starts the unit's dependencies. We want to start networkd only on first
 # boot.
 if $(cmdline_bool coreos.first_boot 0); then
-    add_requires ignition-disks.service
+#   add_requires ignition-disks.service
     # we want this to run before initrd-switch-root.service, not initrd.target,
     # because it needs to run after ostree-prepare-root.service.
     add_requires ignition-files.service initrd-switch-root.service

--- a/dracut/30ignition/module-setup.sh
+++ b/dracut/30ignition/module-setup.sh
@@ -32,8 +32,8 @@ install() {
     inst_simple "$moddir/ignition-generator" \
         "$systemdutildir/system-generators/ignition-generator"
 
-    inst_simple "$moddir/ignition-disks.service" \
-        "$systemdsystemunitdir/ignition-disks.service"
+#   inst_simple "$moddir/ignition-disks.service" \
+#       "$systemdsystemunitdir/ignition-disks.service"
 
     inst_simple "$moddir/ignition-files.service" \
         "$systemdsystemunitdir/ignition-files.service"


### PR DESCRIPTION

    no disks for now - boot systemd unit ordering issue

    without ignition-disks we get a booting system. This is somehow
    related to the ordering with ignition and ostree mounting during
    the initramfs. Disable ignition-disks service for now.
