### PR TITLE
Add ignition-ask-var-mount.service

### DIFF
--- a/dracut/30ignition/ignition-ask-var-mount.service
+++ b/dracut/30ignition/ignition-ask-var-mount.service
@@ -1,0 +1,16 @@
+# This is a workaround to be used in conjunction with
+# https://github.com/ostreedev/ostree/pull/1617.
+
+# The proper long-term fix is to find and do the /var mount
+# in the initramfs.
+
+[Unit]
+Description=Ask OSTree to mount /var in initramfs
+DefaultDependencies=false
+After=initrd-switch-root.target
+Before=ostree-prepare-root.service
+
+[Service]
+Type=oneshot
+ExecStart=/bin/mkdir -p /run/ostree
+ExecStart=/bin/touch /run/ostree/initramfs-mount-var

--- a/dracut/30ignition/ignition-generator
+++ b/dracut/30ignition/ignition-generator
@@ -41,6 +41,7 @@ if $(cmdline_bool coreos.first_boot 0); then
     # we want this to run before initrd-switch-root.service, not initrd.target,
     # because it needs to run after ostree-prepare-root.service.
     add_requires ignition-files.service initrd-switch-root.service
+    add_requires ignition-ask-var-mount.service initrd-switch-root.service
     # Only try to mount the ESP if GRUB detected a first_boot file
     #if [[ $(cmdline_arg coreos.first_boot) = "detected" ]]; then
     #    add_requires ignition-quench.service

--- a/dracut/30ignition/ignition-remount-sysroot.service
+++ b/dracut/30ignition/ignition-remount-sysroot.service
@@ -7,8 +7,10 @@ DefaultDependencies=no
 After=sysroot.mount
 #Before=sysroot-usr.mount
 ConditionPathIsReadWrite=!/sysroot
+After=ostree-prepare-root.service
 
 [Service]
 Type=oneshot
 RemainAfterExit=yes
 ExecStart=/bin/mount -o remount,rw /sysroot
+ExecStart=/bin/mount -o remount,rw /sysroot/var

--- a/dracut/30ignition/module-setup.sh
+++ b/dracut/30ignition/module-setup.sh
@@ -21,7 +21,8 @@ install() {
         sgdisk \
         systemd-detect-virt \
         useradd \
-        usermod
+        usermod \
+        touch
 
 #   inst_script "$moddir/ignition-setup.sh" \
 #       "/usr/sbin/ignition-setup"
@@ -37,6 +38,9 @@ install() {
 
     inst_simple "$moddir/ignition-files.service" \
         "$systemdsystemunitdir/ignition-files.service"
+
+    inst_simple "$moddir/ignition-ask-var-mount.service" \
+        "$systemdsystemunitdir/ignition-ask-var-mount.service"
 
     inst_simple "$moddir/ignition-remount-sysroot.service" \
         "$systemdutildir/system/ignition-remount-sysroot.service"


### PR DESCRIPTION
This new service file adds a special file in `/run` and runs before
`ostree-prepare-root.service` so that the latter mounts `/var` rather
than relying on the OSTree generator post-switchroot.

This also requires us to remount `/var` read-write so that Ignition can
e.g. create new users.