### PR TITLE
ignition-generator: add hack for openstack support

### DIFF
--- a/dracut/30ignition/ignition-generator
+++ b/dracut/30ignition/ignition-generator
@@ -109,6 +109,9 @@ fi
 # For now let's assume ec2 if we get xen
 if [[ $(systemd-detect-virt || true) =~ ^xen$ ]]; then
     oem_id=ec2
+# Also try to auto-detect openstack
+elif dmidecode -s system-product-name | grep -i openstack; then
+    oem_id=openstack
 fi
 
 echo "OEM_ID=$(cmdline_arg coreos.oem.id ${oem_id})" > /run/ignition.env

--- a/dracut/30ignition/module-setup.sh
+++ b/dracut/30ignition/module-setup.sh
@@ -22,7 +22,8 @@ install() {
         systemd-detect-virt \
         useradd \
         usermod \
-        touch
+        touch \
+        dmidecode
 
 #   inst_script "$moddir/ignition-setup.sh" \
 #       "/usr/sbin/ignition-setup"


### PR DESCRIPTION
This is another hack like the xen = ec2 one to get RHCOS ignition
working in OpenStack for now. A lot of our infra and scripts currently
interop well with OpenStack, so unblocking this should make it easier to
iterate on testing RHCOS overall.