### PR TITLE
Drop 'auto-detect' hacks in generator

### DIFF
--- a/dracut/30ignition/ignition-generator
+++ b/dracut/30ignition/ignition-generator
@@ -106,12 +106,4 @@ if [[ $(systemd-detect-virt || true) =~ ^(kvm|qemu)$ ]]; then
     oem_id=qemu
 fi
 
-# For now let's assume ec2 if we get xen
-if [[ $(systemd-detect-virt || true) =~ ^xen$ ]]; then
-    oem_id=ec2
-# Also try to auto-detect openstack
-elif dmidecode -s system-product-name | grep -i openstack; then
-    oem_id=openstack
-fi
-
 echo "OEM_ID=$(cmdline_arg coreos.oem.id ${oem_id})" > /run/ignition.env

--- a/dracut/30ignition/module-setup.sh
+++ b/dracut/30ignition/module-setup.sh
@@ -22,8 +22,7 @@ install() {
         systemd-detect-virt \
         useradd \
         usermod \
-        touch \
-        dmidecode
+        touch
 
 #   inst_script "$moddir/ignition-setup.sh" \
 #       "/usr/sbin/ignition-setup"


### PR DESCRIPTION
We now explicitly stamp images for their respective cloud providers so
we no longer need to try to guess.